### PR TITLE
Make MHPMCOUNTER3..32 Flexible

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -211,26 +211,24 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
       csrmap[CSR_CYCLEH] = std::make_shared<counter_proxy_csr_t>(proc, CSR_CYCLEH, mcycleh);
     }
   }
-  for (reg_t i = 3; i <= 31; ++i) {
-    const reg_t which_mevent = CSR_MHPMEVENT3 + i - 3;
-    const reg_t which_mcounter = CSR_MHPMCOUNTER3 + i - 3;
-    const reg_t which_mcounterh = CSR_MHPMCOUNTER3H + i - 3;
-    const reg_t which_counter = CSR_HPMCOUNTER3 + i - 3;
-    const reg_t which_counterh = CSR_HPMCOUNTER3H + i - 3;
-    auto mevent = std::make_shared<const_csr_t>(proc, which_mevent, 0);
-    auto mcounter = std::make_shared<const_csr_t>(proc, which_mcounter, 0);
+  for (reg_t i = 0; i <= 28; ++i) {
+    const reg_t which_mevent = CSR_MHPMEVENT3 + i;
+    const reg_t which_mcounter = CSR_MHPMCOUNTER3 + i;
+    const reg_t which_mcounterh = CSR_MHPMCOUNTER3H + i;
+    const reg_t which_counter = CSR_HPMCOUNTER3 + i;
+    const reg_t which_counterh = CSR_HPMCOUNTER3H + i;
+    auto mevent = std::make_shared<const_csr_t>(proc, which_mevent, 1<<i);
     csrmap[which_mevent] = mevent;
-    csrmap[which_mcounter] = mcounter;
+    csrmap[which_mcounter] = mcounter[i] = std::make_shared<wide_counter_csr_t>(proc, which_mcounter);
 
     if (proc->extension_enabled_const(EXT_ZICNTR) && proc->extension_enabled_const(EXT_ZIHPM)) {
-      auto counter = std::make_shared<counter_proxy_csr_t>(proc, which_counter, mcounter);
+      auto counter = std::make_shared<counter_proxy_csr_t>(proc, which_counter, mcounter[i]);
       csrmap[which_counter] = counter;
     }
     if (xlen == 32) {
-      auto mcounterh = std::make_shared<const_csr_t>(proc, which_mcounterh, 0);
-      csrmap[which_mcounterh] = mcounterh;
+      csrmap[which_mcounterh] = mcounterh[i] = std::make_shared<counter_top_csr_t>(proc, which_mcounterh, mcounter[i]);
       if (proc->extension_enabled_const(EXT_ZICNTR) && proc->extension_enabled_const(EXT_ZIHPM)) {
-        auto counterh = std::make_shared<counter_proxy_csr_t>(proc, which_counterh, mcounterh);
+        auto counterh = std::make_shared<counter_proxy_csr_t>(proc, which_counterh, mcounterh[i]);
         csrmap[which_counterh] = counterh;
       }
     }

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -142,6 +142,8 @@ struct state_t
   csr_t_p mcause;
   wide_counter_csr_t_p minstret;
   wide_counter_csr_t_p mcycle;
+  wide_counter_csr_t_p mcounter[30];
+  counter_top_csr_t_p mcounterh[30];
   mie_csr_t_p mie;
   mip_csr_t_p mip;
   csr_t_p medeleg;


### PR DESCRIPTION
This one is related with this issue: https://github.com/lowRISC/ibex/issues/1692. I believe we need to let Spike know about `mhpmcounterN` registers so that we can run some tests using those CSRs. Before, it was hardwired to 0 in Spike. Also a change in `mhpmevent` register to make it compatible with Ibex (not sure how it's not causing problems beforehand, it was again tied to 0 but we hardwire each register to something else.)

I'd like to hear your feedback about both `mhpmevent` situation and overall commit, thanks a lot.