### PR TITLE
Revert "pmp: mstatus.mprv should be clear if mpp is not M-mode"

### DIFF
--- a/riscv/insns/mret.h
+++ b/riscv/insns/mret.h
@@ -3,8 +3,6 @@ set_pc_and_serialize(p->get_state()->mepc->read());
 reg_t s = STATE.mstatus->read();
 reg_t prev_prv = get_field(s, MSTATUS_MPP);
 reg_t prev_virt = get_field(s, MSTATUS_MPV);
-if (prev_prv != PRV_M)
-  s = set_field(s, MSTATUS_MPRV, 0);
 s = set_field(s, MSTATUS_MIE, get_field(s, MSTATUS_MPIE));
 s = set_field(s, MSTATUS_MPIE, 1);
 s = set_field(s, MSTATUS_MPP, p->extension_enabled('U') ? PRV_U : PRV_M);

--- a/riscv/insns/sret.h
+++ b/riscv/insns/sret.h
@@ -22,6 +22,4 @@ if (!STATE.v) {
     reg_t new_hstatus = set_field(prev_hstatus, HSTATUS_SPV, 0);
     STATE.hstatus->write(new_hstatus);
   }
-
-  STATE.mstatus->write(set_field(STATE.mstatus->read(), MSTATUS_MPRV, 0));
 }


### PR DESCRIPTION
This reverts commit 327084128246e5cf562293cfe82d2570a6d5629e.

Main idea is to have a working regression for PMP tests meanwhile we are deciding what to do with the general issue of mismatch between Spike and Ibex regarding implementation of a specific version of privilege spec

Related with https://github.com/lowRISC/ibex/issues/1712