### PR TITLE
[HACK] Hardcode debug-related addresses to work with ibex regression

### DIFF
--- a/riscv/debug_rom_defines.h
+++ b/riscv/debug_rom_defines.h
@@ -18,6 +18,6 @@
 // These needs to match the link.ld         
 #define DEBUG_ROM_WHERETO 0x300
 #define DEBUG_ROM_ENTRY   0x80000000
-#define DEBUG_ROM_TVEC    0x808
+#define DEBUG_ROM_TVEC    0x80000004
 
 #endif

--- a/riscv/decode.h
+++ b/riscv/decode.h
@@ -424,7 +424,13 @@ inline long double to_f(float128_t f) { long double r; memcpy(&r, &f, sizeof(r))
   reg_t s##field = get_field(STATE.senvcfg->read(), SENVCFG_##field); \
   reg_t h##field = get_field(STATE.henvcfg->read(), HENVCFG_##field)
 
-#define DEBUG_START             0x0
-#define DEBUG_END               (0x1000 - 1)
+// lowRISC HACK - FIXME  // (original-values)
+// These values are used for the Spike debug_module (which we don't use), and
+// also to define an access check (mmu_t::mmio_ok), which disallows access to
+// debug region when not in debug mode.
+// The Debug_Rom in the ibex regression testbench can move around, so this would
+// need to be tied to built values somehow, or modified to be set at runtime.
+#define DEBUG_START             0x40000000   // (0x0)
+#define DEBUG_END               0x40000000   // (0x1000 - 1)
 
 #endif


### PR DESCRIPTION
This is a quick-fix to get the regressions running, with a better long-term solution needed.
e.g. 
- Build spike as part of the ibex regression (vendoring)?
- Modify spike to allow more control of these addresses at runtime.

Goes towards https://github.com/lowRISC/ibex/issues/1690 