### PR TITLE
Do not set pmpcfg0/pmpaddr0 while resetting.

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -506,14 +506,7 @@ void processor_t::reset()
   halt_on_reset = false;
   VU.reset();
 
-  if (n_pmp > 0) {
-    // For backwards compatibility with software that is unaware of PMP,
-    // initialize PMP to permit unprivileged access to all of memory.
-    put_csr(CSR_PMPADDR0, ~reg_t(0));
-    put_csr(CSR_PMPCFG0, PMP_R | PMP_W | PMP_X | PMP_NAPOT);
-  }
-
-   for (auto e : custom_extensions) // reset any extensions
+  for (auto e : custom_extensions) // reset any extensions
     e.second->reset();
 
   if (sim)


### PR DESCRIPTION
This was causing mismatch between Ibex and Spike. We already handle PMP configurations in our DV environment.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>