### PR TITLE
Fix CPUCTRL CSR

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -1314,12 +1314,12 @@ bool vxsat_csr_t::unlogged_write(const reg_t val) noexcept {
 }
 
 
-cpuctrl_csr_t::cpuctrl_csr_t(processor_t* const proc, const reg_t addr, bool secure_ibex, bool icache_en):
-  csr_t(proc, addr), secure_ibex(secure_ibex), icache_en(icache_en) {
+cpuctrl_csr_t::cpuctrl_csr_t(processor_t* const proc, const reg_t addr):
+  csr_t(proc, addr) {
 }
 
 reg_t cpuctrl_csr_t::read() const noexcept {
-  reg_t mask = (secure_ibex ? 0x3e : 0) | (icache_en ? 0x1 : 0);
+  reg_t mask = (proc->get_secure_ibex() ? 0x3e : 0) | (proc->get_icache_en() ? 0x1 : 0);
   return value & mask;
 }
 

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -714,13 +714,11 @@ class vxsat_csr_t: public masked_csr_t {
 
 class cpuctrl_csr_t: public csr_t {
  public:
-  cpuctrl_csr_t(processor_t* const proc, const reg_t addr, bool secure_ibex, bool icache_en);
+  cpuctrl_csr_t(processor_t* const proc, const reg_t addr);
   virtual reg_t read() const noexcept override;
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;
  private:
-  bool secure_ibex;
-  bool icache_en;
   reg_t value;
 };
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -392,9 +392,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   csrmap[CSR_HENVCFG] = henvcfg = std::make_shared<henvcfg_csr_t>(proc, CSR_HENVCFG, henvcfg_mask, henvcfg_init, menvcfg);
 
   // Ibex-specific CSRs
-  csrmap[CSR_CPUCTRL] = std::make_shared<cpuctrl_csr_t>(proc, CSR_CPUCTRL,
-                                                        proc->get_secure_ibex(),
-                                                        proc->get_icache_en());
+  csrmap[CSR_CPUCTRL] = std::make_shared<cpuctrl_csr_t>(proc, CSR_CPUCTRL);
   csrmap[CSR_SECURESEED] = std::make_shared<const_csr_t>(proc, CSR_SECURESEED, 0);
 
   serialized = false;


### PR DESCRIPTION
The CPUCTRL CSR gets set up in the processor_t constructor which is
before the cosim has a chance to set the icache and secure parameters.
This alters the CPUCTRL CSR so it looks at those parameters in the
processor instance, rather than taking a copy on construction, to ensure
it captures the correct values.