### PR TITLE
Unify PMPCFGx behaviour with PMPADDRx where PMP is disabled

### DIFF
--- a/riscv/csrs.cc
+++ b/riscv/csrs.cc
@@ -234,6 +234,16 @@ pmpcfg_csr_t::pmpcfg_csr_t(processor_t* const proc, const reg_t addr):
   csr_t(proc, addr) {
 }
 
+void pmpcfg_csr_t::verify_permissions(insn_t insn, bool write) const {
+  csr_t::verify_permissions(insn, write);
+  // If n_pmp is zero, that means pmp is not implemented hence raise
+  // trap if it tries to access the csr. I would prefer to implement
+  // this by not instantiating any pmpaddr_csr_t for these regs, but
+  // n_pmp can change after reset() is run.
+  if (proc->n_pmp == 0)
+    throw trap_illegal_instruction(insn.bits());
+}
+
 reg_t pmpcfg_csr_t::read() const noexcept {
   reg_t cfg_res = 0;
   for (size_t i0 = (address - CSR_PMPCFG0) * 4, i = i0; i < i0 + proc->get_xlen() / 8 && i < state->max_pmp; i++)

--- a/riscv/csrs.h
+++ b/riscv/csrs.h
@@ -122,6 +122,7 @@ typedef std::shared_ptr<pmpaddr_csr_t> pmpaddr_csr_t_p;
 class pmpcfg_csr_t: public csr_t {
  public:
   pmpcfg_csr_t(processor_t* const proc, const reg_t addr);
+  virtual void verify_permissions(insn_t insn, bool write) const override;
   virtual reg_t read() const noexcept override;
  protected:
   virtual bool unlogged_write(const reg_t val) noexcept override;


### PR DESCRIPTION
Previously any access to the PMPADDRx CSRs when no PMP regions were
configured would result in an illegal instruction trap, whilst
PMPCFGx registers would act as WARL, ignoring writes and reading as 0.

This unifies the behaviour so both PMPADDRx and PMPCFGx CSRs produce an
illegal instruction trap when accessed when no PMP regions are
configured.