### PR TITLE
Add Internal NMI field in Spike

### DIFF
--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -245,8 +245,7 @@ bool mmu_t::pmp_ok(reg_t addr, reg_t len, access_type type, reg_t mode)
   // in case matching region is not found
   const bool mseccfg_mml = proc->state.mseccfg->get_mml();
   const bool mseccfg_mmwp = proc->state.mseccfg->get_mmwp();
-  return ((mode == PRV_M) && !mseccfg_mmwp
-          && (!mseccfg_mml || ((type == LOAD) || (type == STORE))));
+  return ((mode == PRV_M) && (!mseccfg_mmwp) && ((!mseccfg_mml) || (type == LOAD) || (type == STORE)));
 }
 
 reg_t mmu_t::pmp_homogeneous(reg_t addr, reg_t len)

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -398,6 +398,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   serialized = false;
 
   nmi = false;
+  nmi_int = false;
 
 #ifdef RISCV_ENABLE_COMMITLOG
   log_reg_write.clear();
@@ -733,7 +734,9 @@ void processor_t::take_trap(trap_t& t, reg_t epc)
 
   // By default, trap to M-mode, unless delegated to HS-mode or VS-mode
   reg_t vsdeleg, hsdeleg;
-  reg_t bit = t.cause();
+  reg_t bit = state.nmi_int ? ((reg_t)1 << (get_isa().get_max_xlen()-1)) | NMI_INTERRUPT_NUM :
+                              t.cause();
+  state.nmi_int = state.nmi_int ? false : state.nmi_int;
   bool curr_virt = state.v;
   bool interrupt = (bit & ((reg_t)1 << (max_xlen - 1))) != 0;
   if (interrupt) {

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -202,6 +202,7 @@ struct state_t
   } single_step;
 
   bool nmi;
+  bool nmi_int;
 
 #ifdef RISCV_ENABLE_COMMITLOG
   commit_log_reg_t log_reg_write;
@@ -364,6 +365,9 @@ private:
     if (!state.debug_mode && state.nmi) {
       state.nmi = false;
       throw trap_t(((reg_t)1 << (get_isa().get_max_xlen()-1)) | NMI_INTERRUPT_NUM);
+    }
+    if (!state.debug_mode && state.nmi_int) {
+      throw trap_t(((reg_t)1 << get_isa().get_max_xlen()) - 1 - NMI_INTERRUPT_NUM);
     }
 
     take_interrupt(state.mip->read() & state.mie->read());


### PR DESCRIPTION
Basically sets an extra state variable in which we take a NMI as well.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>