### PR TITLE
Change mtval on ebreak behaviour to match ibex

### DIFF
--- a/riscv/insns/c_ebreak.h
+++ b/riscv/insns/c_ebreak.h
@@ -1,2 +1,2 @@
 require_extension('C');
-throw trap_breakpoint(STATE.v, pc);
+throw trap_breakpoint(STATE.v, 0);

--- a/riscv/insns/ebreak.h
+++ b/riscv/insns/ebreak.h
@@ -1,1 +1,1 @@
-throw trap_breakpoint(STATE.v, pc);
+throw trap_breakpoint(STATE.v, 0);


### PR DESCRIPTION
This matches the [documented ibex behaviour](https://github.com/lowRISC/ibex/blame/master/doc/03_reference/cs_registers.rst#L227) for setting mtval upon an ebreak exception. See comments [in this issue](https://github.com/lowRISC/ibex/issues/1769) for more details.