### PR TITLE
Hardcode MHPM event register wrt. MHPMCounterNum

### DIFF
--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -217,8 +217,16 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
     const reg_t which_mcounterh = CSR_MHPMCOUNTER3H + i;
     const reg_t which_counter = CSR_HPMCOUNTER3 + i;
     const reg_t which_counterh = CSR_HPMCOUNTER3H + i;
-    auto mevent = std::make_shared<const_csr_t>(proc, which_mevent, 1<<i);
-    csrmap[which_mevent] = mevent;
+    if (i < proc->num_mhpm_counters)
+    {
+      auto mevent = std::make_shared<const_csr_t>(proc, which_mevent, 1<<i);
+      csrmap[which_mevent] = mevent;
+    }
+    else
+    {
+      auto mevent = std::make_shared<const_csr_t>(proc, which_mevent, 0);
+      csrmap[which_mevent] = mevent;
+    }
     csrmap[which_mcounter] = mcounter[i] = std::make_shared<wide_counter_csr_t>(proc, which_mcounter);
 
     if (proc->extension_enabled_const(EXT_ZICNTR) && proc->extension_enabled_const(EXT_ZIHPM)) {
@@ -585,6 +593,11 @@ void processor_t::set_ibex_flags(bool si, bool ie)
 {
   secure_ibex = si;
   icache_en = ie;
+}
+
+void processor_t::set_mhpm_counter_num(reg_t mhpm_counter_num)
+{
+  num_mhpm_counters = mhpm_counter_num;
 }
 
 void processor_t::take_interrupt(reg_t pending_interrupts)

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -327,6 +327,7 @@ public:
 
   void set_pmp_num(reg_t pmp_num);
   void set_pmp_granularity(reg_t pmp_granularity);
+  void set_mhpm_counter_num(reg_t mhpm_counter_num);
   void set_mmu_capability(int cap);
   void set_ibex_flags(bool secure_ibex, bool icache_en);
 
@@ -392,6 +393,7 @@ private:
 public:
   entropy_source es; // Crypto ISE Entropy source.
 
+  reg_t num_mhpm_counters;
   reg_t n_pmp;
   reg_t lg_pmp_granularity;
   reg_t pmp_tor_mask() { return -(reg_t(1) << (lg_pmp_granularity - PMP_SHIFT)); }


### PR DESCRIPTION
Ibex related change to match the hardcoding behaviour on the RTL side. We deactivate the upper event registers according to the parameter MHPMCounterNum.

In relation with: https://github.com/lowRISC/ibex/pull/1821

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>