### PR TITLE
Include cstdint in fesvr/device.h

### DIFF
--- a/fesvr/device.h
+++ b/fesvr/device.h
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <string>
 #include <functional>
+#include <cstdint>
 
 class memif_t;
 


### PR DESCRIPTION
Hello, not sure if this fork is still maintained, but the documentation of Ibex verification at https://ibex-core.readthedocs.io/en/latest/03_reference/verification.html points to here.

This PR incorporates changes made to the upstream repo in this PR: https://github.com/riscv-software-src/riscv-isa-sim/pull/1284

Please let me know if any changes are needed. As you can see I am a first time contributor to this repo. Thanks!