### PR TITLE
Allow all debug module accesses in debug mode

### DIFF
--- a/riscv/debug_rom_defines.h
+++ b/riscv/debug_rom_defines.h
@@ -18,6 +18,6 @@
 // These needs to match the link.ld         
 #define DEBUG_ROM_WHERETO 0x300
 #define DEBUG_ROM_ENTRY   0x80000000
-#define DEBUG_ROM_TVEC    0x80000004
+#define DEBUG_ROM_TVEC    0x80000008
 
 #endif

--- a/riscv/mmu.cc
+++ b/riscv/mmu.cc
@@ -218,6 +218,11 @@ bool mmu_t::pmp_ok(reg_t addr, reg_t len, access_type type, reg_t mode)
   if (!proc || proc->n_pmp == 0)
     return true;
 
+  // If the access is into the debug module in debug_mode, it must
+  // always succeed.
+  if (addr >= proc->start_debug && addr < proc->end_debug && proc && proc->state.debug_mode)
+    return true;
+
   for (size_t i = 0; i < proc->n_pmp; i++) {
     // Check each 4-byte sector of the access
     bool any_match = false;

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -490,6 +490,12 @@ void processor_t::set_debug(bool value)
     e.second->set_debug(value);
 }
 
+void processor_t::set_debug_module_range(reg_t start_debug_val, reg_t end_debug_val)
+{
+  start_debug = start_debug_val;
+  end_debug = end_debug_val;
+}
+
 void processor_t::set_histogram(bool value)
 {
   histogram_enabled = value;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -242,6 +242,7 @@ public:
   const isa_parser_t &get_isa() { return *isa; }
 
   void set_debug(bool value);
+  void set_debug_module_range(reg_t start_debug_val, reg_t end_debug_val);
   void set_histogram(bool value);
 #ifdef RISCV_ENABLE_COMMITLOG
   void enable_log_commits();
@@ -358,6 +359,8 @@ private:
   bool icache_en;
   bool ic_scr_key_valid;
   std::vector<bool> impl_table;
+  reg_t start_debug = DEBUG_START;
+  reg_t end_debug = DEBUG_END;
 
   std::vector<insn_desc_t> instructions;
   std::map<reg_t,uint64_t> pc_histogram;


### PR DESCRIPTION
Please do not merge without coordination. Due to the way we currently tie together the ibex regressions with the version of spike to co-simulate against, merging requires some other consideration to ensure minimal breakage for some users.

---

This feature is added to match the Ibex implementation.

Instead of using the preprocessor macros to define the base+range for the debug module, allow the values to be configured at run time by adding them to the processor_t class. Note that the built-in debug module model (`debug_module.cc`) still uses these symbols, but we do not make use of that model for Ibex simulation, so leaving that as an inconsistency is acceptable.


