### PR TITLE
Enable ZIHPM unpriviledged performance counters

### DIFF
--- a/riscv/isa_parser.cc
+++ b/riscv/isa_parser.cc
@@ -36,7 +36,7 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
   max_isa = reg_t(2) << 62;
   // enable zicntr and zihpm unconditionally for backward compatibility
   extension_table[EXT_ZICNTR] = true;
-  extension_table[EXT_ZIHPM] = false; // IBEX does not implement this extension
+  extension_table[EXT_ZIHPM] = true;
 
   if (isa_string.compare(0, 4, "rv32") == 0)
     max_xlen = 32, max_isa = reg_t(1) << 30;


### PR DESCRIPTION
We are adding support for the U-mode performance counters in https://github.com/lowRISC/ibex/pull/2403. Therefore, we are re-enabling them here as well.